### PR TITLE
Dev unstable

### DIFF
--- a/proofs/correct_option_derivative.v
+++ b/proofs/correct_option_derivative.v
@@ -30,13 +30,11 @@ Proof.
     + ctr_case_analysis ctr ctr0.
       execute_own ctr H10.
       case_if H10.
-      case_if H13.
       * eexists. split.
         ** eapply steps_does_not_remove_transactions; eauto.
            simpl. subst ledger'. left. eauto.
         ** repeat split; trivial. resolve_owner H5.
-      * simpl in *. rewrite <- T0 in *.
-        apply ltb_sound_false in H10. contradiction H10.
+      * apply ltb_sound_false in H0. contradiction H0. subst T. trivial.
     + not_or ctr ctr0 H7.
     + not_or ctr ctr0 H7.
     + inversion_event Ev. find_contradiction H.
@@ -50,10 +48,6 @@ Proof.
     + ctr_case_analysis ctr ctr0.
       execute_own ctr H8.
       case_if H8.
-      * apply ltb_sound_true in H0.
-        apply Nat.lt_asymm in H0.
-        contradict H0. apply infinite.
-      * case_if H11.
     + find_contradiction_del H.
 Qed.
 
@@ -81,31 +75,18 @@ Proof.
     + ctr_case_analysis ctr ctr0.
       execute_own ctr H12.
       case_analysis H12.
-      case_analysis H15.
-      * case_analysis H16.
-        case_analysis H17; simpl in *;
-          rewrite H0, H12, H14, H15 in Exec; inversion Exec; clear Exec;
-            rewrite <- H17 in M0; simpl in M0.
-        ** destruct M0 as [M0 | M0]; try contradiction.
-           rewrite <- M0 in H2. simpl in H2. inversion H2.
-        ** destruct M0 as [M0 | [M0 | M0]]; try contradiction.
-           *** rewrite <- M0 in H2. simpl in H2. inversion H2.
-           *** eapply option_I_to_O_helper; eauto.
-               rewrite <- M0 in J.
-               rewrite <- M0. simpl.               
-               exact J.
-      * case_analysis H16.
-        case_analysis H17; simpl in *;
-          rewrite H0, H12, H14, H15 in Exec; inversion Exec; clear Exec;
-            rewrite <- H17 in M0; simpl in M0.
-        ** destruct M0 as [M0 | M0]; try contradiction.
-           rewrite <- M0 in H2. simpl in H2. inversion H2.
-        ** destruct M0 as [M0 | [M0 | M0]]; try contradiction.
-           *** rewrite <- M0 in H2. simpl in H2. inversion H2.
-           *** eapply option_I_to_O_helper; eauto.
-               rewrite <- M0 in J.
-               rewrite <- M0. simpl.               
-               exact J.
+      case_analysis H15; simpl in Exec;
+        rewrite H0, H12 in Exec; inversion Exec; clear Exec; subst res.
+      * simpl in M0.
+        destruct M0 as [M0 | M0]; try contradiction.
+        rewrite <- M0 in H2. simpl in H2. inversion H2.
+      * destruct M0 as [M0 | M0]; try contradiction.
+        rewrite <- M0 in H2. simpl in H2. inversion H2.
+        destruct M0 as [M0 | M0]; try contradiction.
+        eapply option_I_to_O_helper; eauto.
+        rewrite <- M0 in J.
+        rewrite <- M0. simpl.               
+        exact J.
     + not_or ctr ctr0 H9.
     + not_or ctr ctr0 H9.
     + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
@@ -124,14 +105,6 @@ Proof.
       * unfold option_derivative in Exec. simpl in Exec.
         rewrite H0 in Exec. inversion Exec.
       * case_analysis H13.
-        ** case_analysis H14.
-           *** unfold option_derivative in Exec. simpl in Exec.
-               rewrite H0, H10, H12 in Exec. inversion Exec.
-           *** case_analysis H15.
-        ** case_analysis H15.
-           *** unfold option_derivative in Exec. simpl in Exec.
-               rewrite H0, H10, H12 in Exec. inversion Exec.
-           *** case_analysis H15.
     + find_contradiction_del M.
 Qed.
 
@@ -161,17 +134,11 @@ Proof.
     + ctr_case_analysis ctr ctr0. simpl.
       execute_own ctr H10.
       case_analysis H10.
-      case_analysis H13.
-      * case_analysis H14.
-        case_analysis H15; subst ctrs'; eexists; split.
-        ** rewrite in_app_iff. right.  simpl. left. trivial.
-        ** repeat split; trivial. resolve_owner H5.
-        ** rewrite in_app_iff. right. simpl. left. trivial.
-        ** repeat split; trivial. resolve_owner H5.
-      * case_analysis H14.
-        case_analysis H15.
-        ** subst t. apply ltb_sound_true in H13. contradict H13. omega.
-        ** subst t. apply ltb_sound_false in H10. contradict H10. omega.
+      case_analysis H13; resolve_owner H5; eexists. 
+      * split. rewrite in_app_iff. right. simpl. left. trivial.
+        repeat split; trivial.
+      * split. rewrite in_app_iff. right. simpl. left. trivial.
+        repeat split; trivial.
     + not_or ctr ctr0 H7.
     + not_or ctr ctr0 H7.
     + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
@@ -188,16 +155,6 @@ Proof.
       case_analysis H8.
       * subst t. apply ltb_sound_true in H0. contradict H0. omega.
       * case_analysis H11.
-        ** case_analysis H12.
-           ***  apply ltb_sound_true in H10.
-                apply Nat.lt_asymm in H10.
-                contradict H10. apply infinite.
-           *** case_analysis H13.
-        ** case_analysis H12.
-           ***  apply ltb_sound_true in H10.
-                apply Nat.lt_asymm in H10.
-                contradict H10. apply infinite.
-           *** case_analysis H13.
     + find_contradiction_del M.
 Qed.     
 
@@ -279,22 +236,16 @@ Proof.
       execute_own ctr H12.
       case_analysis H12.
       case_analysis H15.
-      * case_analysis H16.
-        case_analysis H17.
-        ** subst t. apply ltb_sound_true in H15. contradict H15. omega.
-        ** simpl in Exec. rewrite H0, H12, H14, H15 in Exec.
-           inversion Exec. subst res. simpl in *.
-           destruct M0 as [M0 | [M0 | M0]]; try contradiction.
-           *** eapply option_O_to_I_helper in J; auto; rewrite <- M0. simpl.
-               exact J. eauto.
-           *** rewrite <- M0 in H2. simpl in H2. inversion H2.
-      * case_analysis H15.
-        case_analysis H16.
-        ** subst t. apply ltb_sound_true in H15. contradict H15. omega.
-        ** simpl in Exec. rewrite H0, H12, H14, H15 in Exec.
-           inversion Exec. subst res. simpl in *.
-           destruct M0 as [M0 | [M0 | M0]]; try contradiction;
-             rewrite <- M0 in H2; simpl in H2; inversion H2.
+      * apply ltb_sound_true in H12.
+        apply ltb_sound_false in H0.
+        omega.
+      * simpl in Exec. rewrite H0, H12 in Exec.
+        inversion Exec. clear Exec.
+        subst res.
+        simpl in M0.
+        destruct M0 as [M0 | [M0 | M0]]; try contradiction; subst gen_ctr; simpl in *.
+        ** eapply option_O_to_I_helper; eauto.
+        ** inversion H2.
     + not_or ctr ctr0 H9.
     + not_or ctr ctr0 H9.
     + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
@@ -311,11 +262,7 @@ Proof.
       execute_own ctr H10.
       case_analysis H10.
       * simpl in Exec. rewrite H0 in Exec. inversion Exec.
-      * case_analysis H13;
-         case_analysis H14; try case_analysis H15;
-           apply ltb_sound_true in H12;
-           apply Nat.lt_asymm in H12;
-           contradict H12; eapply infinite.
+      * case_analysis H13.
     + find_contradiction_del M.
 Qed.
 

--- a/proofs/correct_option_derivative.v
+++ b/proofs/correct_option_derivative.v
@@ -27,7 +27,7 @@ Proof.
   - insert_consistent s Ss.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction H.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0. 
       execute_own ctr H10.
       case_if H10.
       * eexists. split.
@@ -35,17 +35,17 @@ Proof.
            simpl. subst ledger'. left. eauto.
         ** repeat split; trivial. resolve_owner H5.
       * apply ltb_sound_false in H0. contradiction H0. subst T. trivial.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
     + inversion_event Ev. find_contradiction H.
     + find_contradiction H.
   - insert_consistent s Ss.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del H.
     + inversion_event Ev. find_contradiction_del H.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0.
+    + inversion_event Ev. find_contradiction_del H.
+    + inversion_event Ev. find_contradiction_del H.
+    + same_ctr_del Ev. subst ctr0.
       execute_own ctr H8.
       case_if H8.
     + find_contradiction_del H.
@@ -72,7 +72,7 @@ Proof.
     insert_consistent s' St.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0. 
       execute_own ctr H12.
       case_analysis H12.
       case_analysis H15; simpl in Exec;
@@ -87,9 +87,9 @@ Proof.
         rewrite <- M0 in J.
         rewrite <- M0. simpl.               
         exact J.
-    + not_or ctr ctr0 H9.
-    + not_or ctr ctr0 H9.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H9.
+    + same_ctr Ev. subst ctr0. not_or' ctr H9.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - insert_consistent s Ss.
     destruct_deleted D.
@@ -97,9 +97,9 @@ Proof.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
     + inversion_event Ev. find_contradiction_del M.
-    + not_or ctr ctr0 H9.
-    + not_or ctr ctr0 H9.
-    + ctr_case_analysis ctr ctr0.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst  ctr0.
       execute_own ctr H10.
       case_analysis H10.
       * unfold option_derivative in Exec. simpl in Exec.
@@ -131,7 +131,7 @@ Proof.
     destruct_executed E.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0. simpl.
+    + same_ctr Ev. subst ctr0. simpl.
       execute_own ctr H10.
       case_analysis H10.
       case_analysis H13; resolve_owner H5; eexists. 
@@ -139,18 +139,18 @@ Proof.
         repeat split; trivial.
       * split. rewrite in_app_iff. right. simpl. left. trivial.
         repeat split; trivial.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - insert_consistent s Ss1.
     destruct_deleted D.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction_del M.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0.
       execute_own ctr H8.
       case_analysis H8.
       * subst t. apply ltb_sound_true in H0. contradict H0. omega.
@@ -181,8 +181,8 @@ Proof.
     insert_consistent s' St.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0. subst ctr. simpl in H7. contradiction.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0 ctr. simpl in H7. contradiction.
+    + same_ctr Ev. subst ctr0.
       rewrite H0 in H10, H7. simpl in H7. inversion H7.
       unfold exec_prim_ctr_in_state_with_owner in H10.
       subst c1 c2. simpl in H10. inversion H10.
@@ -190,7 +190,7 @@ Proof.
       * eapply steps_does_not_remove_transactions; eauto.
         subst ledger'. simpl. left. trivial.
       * repeat split; trivial. resolve_owner H5.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       rewrite H0 in H10, H7. simpl in H7. inversion H7.
       unfold exec_prim_ctr_in_state_with_owner in H10.
       subst c1 c2. simpl in H10. inversion H10.
@@ -198,16 +198,16 @@ Proof.
       * eapply steps_does_not_remove_transactions; eauto.
         subst ledger'. simpl. left. trivial.
       * repeat split; trivial. resolve_owner H5.
-    + ctr_case_analysis ctr ctr0. execute_own ctr H8. inversion H8.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - insert_consistent s Ss.
     insert_consistent s' St.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
-    + ctr_case_analysis ctr ctr0. subst ctr. simpl in H7. contradiction.
-    + simpl in Ev. inversion_event Ev. find_contradiction_del M.
-    + simpl in Ev. inversion_event Ev. find_contradiction_del M.
-    + ctr_case_analysis ctr ctr0. execute_own ctr H8. inversion H8.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0. execute_own ctr H8. inversion H8.
     + find_contradiction_del M.
 Qed.
 
@@ -232,7 +232,7 @@ Proof.
     insert_consistent s' St.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H12.
       case_analysis H12.
       case_analysis H15.
@@ -246,9 +246,9 @@ Proof.
         destruct M0 as [M0 | [M0 | M0]]; try contradiction; subst gen_ctr; simpl in *.
         ** eapply option_O_to_I_helper; eauto.
         ** inversion H2.
-    + not_or ctr ctr0 H9.
-    + not_or ctr ctr0 H9.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H9.
+    + same_ctr Ev. subst ctr0. not_or' ctr H9.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - insert_consistent s Ss.
     destruct_deleted D.
@@ -256,9 +256,9 @@ Proof.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
     + inversion_event Ev. find_contradiction_del M.
-    + not_or ctr ctr0 H9.
-    + not_or ctr ctr0 H9.
-    + ctr_case_analysis ctr ctr0.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0.
       execute_own ctr H10.
       case_analysis H10.
       * simpl in Exec. rewrite H0 in Exec. inversion Exec.

--- a/proofs/credit_default_swap.v
+++ b/proofs/credit_default_swap.v
@@ -176,7 +176,8 @@ Proof.
   induction l; intros; simpl in *; trivial.
   case_eq (ctr_eq_dec x' a); intros * H'; rewrite H' in H.
   - subst. right. eapply IHl. eauto.
-  - contradiction.
+  - destruct H as [H | H]; auto.
+    right. eapply IHl; eauto.
 Qed.
 
 Lemma h1 :
@@ -200,27 +201,22 @@ Qed.
 
 Lemma exec_later_no_effect :
   forall s1 s2 c T t t' primitive,
+    consistent_state s1 ->
     is_executed c s1 s2 (T + t) ->
     ctr_primitive c = At (T + t') primitive ->
     t - t' > Δ ->
     m_ledger s1 = m_ledger s2.
 Proof.
-  intros * Exec Prim C.
+  intros * CS Exec Prim C.
   destruct_exec Exec.
   induction Step; subst s2; try auto.
-  - ctr_case_analysis c ctr.
-    destruct c. simpl in Prim. subst ctr_primitive0.
-    unfold exec_ctr_in_state_with_owner, execute in H5. simpl in *.
-    case_if H5.
-    clear H9 H6 H3 H H0 H2 H4.
-    rewrite <- T0 in *.
-    apply ltb_sound_false in H7.
-    contradict H7.
-    omega.
-  - ctr_case_analysis c ctr. rewrite Prim in H2. inversion H2.
-  - ctr_case_analysis c ctr. rewrite Prim in H2. inversion H2.
+  - same_ctr InEv.
+    subst ctr. destruct c. simpl in *. subst.
+    unfold exec_ctr_in_state_with_owner, execute in H5; simpl in *.
+    case_if H5. apply ltb_sound_false in H6. omega.
+  - same_ctr InEv. subst ctr. rewrite Prim in H2. inversion H2.
+  - same_ctr InEv. subst ctr. rewrite Prim in H2. inversion H2.
 Qed.
-
 
 (***********************)
 (* Proofs for pay_at_t *)
@@ -245,14 +241,14 @@ Proof.
   destruct_exec Exec.
   induction Step; subst s2.
   - inversion_event InEv. find_contradiction InEv.
-  - ctr_case_analysis c ctr.
+  - same_ctr InEv. subst ctr.
     execute_own c H5.
     case_if H5.
     case_if H9; simpl.
     + subst t.
-      rewrite Q in H10.
+      rewrite Q in H9.
       destruct response; simpl in *; try contradiction.
-      inversion H10. subst.
+      inversion H9. subst.
       eexists.
       split.
       * simpl. left. eauto.
@@ -262,10 +258,9 @@ Proof.
       assert (H' : m_global_time s1 > Δ).
       apply global_time_is_bigger_than_delta. 
       unfold Δ. omega.
-  - not_or c ctr H2.
-  - not_or c ctr H2.
-  - ctr_case_analysis c ctr.
-    inversion_event InEv. find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - inversion_event InEv. find_contradiction InEv.
   - find_contradiction InEv.
 Qed.
 
@@ -282,21 +277,20 @@ Proof.
   destruct_exec Exec.
   induction Step; subst s2.
   - inversion_event InEv. find_contradiction InEv.
-  - ctr_case_analysis c ctr.
+  - same_ctr InEv. subst ctr.
     execute_own c H5.
     case_if H5.
     case_if H9; simpl.
     + subst t.
-      rewrite Q in H10. simpl in *.
-      inversion H10. trivial.
+      rewrite Q in H9. simpl in *.
+      inversion H9. trivial.
     + subst t. apply leb_sound_false in H5. contradict H5.
       assert (H' : m_global_time s1 > Δ).
       apply global_time_is_bigger_than_delta. 
       unfold Δ. omega.
-  - not_or c ctr H2.
-  - not_or c ctr H2.
-  - ctr_case_analysis c ctr.
-    inversion_event InEv. find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - inversion_event InEv. find_contradiction InEv.
   - find_contradiction InEv.
 Qed.
 Print pay_at_t_O_rights.
@@ -323,18 +317,18 @@ Proof.
   destruct_exec Exec.
   induction Step; subst s2.
   - inversion_event InEv. find_contradiction InEv.
-  - ctr_case_analysis c ctr.
+  - same_ctr InEv. subst ctr. 
     execute_own c H5.
     subst t. simpl.
     case_if H5.
     case_if H9; simpl.
-    + rewrite Q1 in H10. simpl in H10.
-      destruct response; try contradiction. simpl in H10.
-      inversion H10. clear H10. subst. trivial.
+    + rewrite Q1 in H9. simpl in H9.
+      destruct response; try contradiction. simpl in H9.
+      inversion H9. clear H9. subst. trivial.
     + trivial.
-  - not_or c ctr H2.
-  - not_or c ctr H2.
-  - ctr_case_analysis c ctr. inversion_event InEv. find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - inversion_event InEv. find_contradiction InEv.
   - find_contradiction InEv.
 Qed.
 
@@ -358,25 +352,25 @@ Proof.
   destruct_exec Exec.
   induction Step; subst s2.
   - inversion_event InEv. find_contradiction InEv.
-  - ctr_case_analysis c ctr.
+  - same_ctr InEv. subst ctr.
     execute_own c H5.
     subst t. simpl.
     case_if H5.
     case_if H9; simpl.
-    + subst. rewrite Q1 in H10. simpl in H10.
-      case_match H10.
-      case_if H8.
-      case_if H12.
-      * apply leb_sound_true in H8. contradict H8. omega.
-      * destruct r. inversion H13. clear H13. subst.
-        inversion H11. clear H11.
+    + subst. rewrite Q1 in H9. simpl in H9.
+      case_match H9.
+      case_if H7.
+      case_if H11.
+      * apply leb_sound_true in H7. contradict H7. omega.
+      * destruct r. inversion H12. clear H12. subst.
+        inversion H10. clear H10.
         eexists. split.
         apply in_app_iff. right. simpl. left. trivial.
         repeat split; trivial. resolve_owner H0.
     + apply leb_sound_false in H5. contradict H5. unfold Δ. omega.
-  - not_or c ctr H2.
-  - not_or c ctr H2.
-  - ctr_case_analysis c ctr. inversion_event InEv. find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - inversion_event InEv. find_contradiction InEv.
   - find_contradiction InEv.
 Qed.
 
@@ -402,31 +396,31 @@ Proof.
   destruct_exec Exec.
   induction Step; subst s2.
   - inversion_event InEv. find_contradiction InEv.
-  - ctr_case_analysis c ctr.
+  - same_ctr InEv.  subst ctr.
     execute_own c H5.
     subst t. simpl.
     case_if H5.
     case_if H9; simpl.
-    + subst. rewrite Q1 in H10. simpl in H10.
-      case_match H10.
-      case_if H8.
-      case_if H12.
-      * destruct r. inversion H13. clear H13. subst.
-        inversion H11. clear H11.
+    + subst. rewrite Q1 in H9. simpl in H9.
+      case_match H9.
+      case_if H7.
+      case_if H11.
+      * destruct r. inversion H12. clear H12. subst.
+        inversion H10. clear H10.
         eexists.  simpl. split. left. trivial.
         repeat split; auto.
         simpl. resolve_owner H0.
         simpl. omega.
-      * destruct r. inversion H13. clear H13. subst.
-        inversion H11. clear H11.
+      * destruct r. inversion H12. clear H12. subst.
+        inversion H10. clear H10.
         eexists.  simpl. split. left. trivial.
         repeat split; auto.
         simpl. resolve_owner H0.
         simpl. omega.
     + apply leb_sound_false in H5. contradict H5. unfold Δ. omega.
-  - not_or c ctr H2.
-  - not_or c ctr H2.
-  - ctr_case_analysis c ctr. inversion_event InEv. find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - same_ctr InEv. subst ctr. not_or' c H2.
+  - inversion_event InEv. find_contradiction InEv.
   - find_contradiction InEv.
 Qed.
 Print yearly_checks_already_defaulted.
@@ -503,7 +497,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now. 
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -517,12 +511,9 @@ Proof.
         eapply pay_at_t_O_rights; eauto. unfold pay_at_t, At. eauto.
       * subst c'. simpl in Prim. unfold pay_at_t, At in Prim. inversion Prim.
       * subst c'. simpl in Prim. unfold pay_at_t, At in Prim. inversion Prim.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    execute_own CDSctr H5. inversion InEv.
-    apply consistent_impl_exec in InCtr0; auto. inversion H7; auto.
-    find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent Cst InEv.
   - simpl in InCtr. contradiction.
 Qed.
 
@@ -566,7 +557,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -584,12 +575,9 @@ Proof.
         exact Exec2.
       * subst c'. inversion Prim.
         contradict H9. omega.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    execute_own CDSctr H5. inversion InEv.
-    apply consistent_impl_exec in InCtr0; auto. inversion H7; auto.
-    find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent Cst InEv.
   - simpl in InCtr. contradiction.
 Qed.
 
@@ -632,7 +620,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -650,12 +638,9 @@ Proof.
         unfold yearly_check, At.
         instantiate (2 := b2afee). instantiate (2 := 0).
         exact Exec2.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    execute_own CDSctr H5. inversion InEv.
-    apply consistent_impl_exec in InCtr0; auto. inversion H7; auto.
-    find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent  Cst InEv.
   - simpl in InCtr. contradiction.
 Qed.
 
@@ -691,7 +676,7 @@ Proof.
   insert_consistent s2 Step.
   induction Step; subst s2.
   - inversion_event InEv. find_contradiction InEv.
-  - ctr_case_analysis CDSctr ctr. clear H7.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H6. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H6; unfold Δ; try auto; try omega.
@@ -700,10 +685,9 @@ Proof.
     eexists. split. simpl. left. trivial.
     repeat split; trivial. simpl. resolve_owner H1.
     simpl. auto.
-  - not_or ctr CDSctr H3.
-  - not_or ctr CDSctr H3.
-  - ctr_case_analysis CDSctr ctr.
-    inversion_event InEv. find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H3.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H3.
+  - inversion_event InEv. inconsistent Cst InEv.
   - find_contradiction InEv.
 Qed.
 Print CDS_Y1_C1.
@@ -769,7 +753,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -783,12 +767,9 @@ Proof.
         eapply pay_at_t_not_defaulted; eauto.
       * subst c'. inversion Prim.
       * subst c'. inversion Prim.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    execute_own CDSctr H5. inversion InEv.
-    apply consistent_impl_exec in InCtr0; auto. inversion H7; auto.
-    find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent Cst InEv.
   - simpl in InCtr. contradiction.
 Qed.
 
@@ -840,7 +821,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -859,12 +840,9 @@ Proof.
         ** omega. 
       * subst c'. inversion Prim.
         contradict H9. omega.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    execute_own CDSctr H5. inversion InEv.
-    apply consistent_impl_exec in InCtr0; auto. inversion H7; auto.
-    find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent Cst InEv.
   - simpl in InCtr. contradiction.
 Qed.
 
@@ -909,7 +887,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -927,12 +905,9 @@ Proof.
         unfold yearly_check, At.
         instantiate (2 := b2afee). instantiate (2 := 0).
         exact Exec2.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    execute_own CDSctr H5. inversion InEv.
-    apply consistent_impl_exec in InCtr0; auto. inversion H7; auto.
-    find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent Cst InEv.
   - simpl in InCtr. contradiction.
 Qed.
 
@@ -985,7 +960,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -1004,11 +979,9 @@ Proof.
         omega.
       * subst c'. inversion Prim.
         contradict H9. omega.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    inversion_event InEv.
-    apply consistent_impl_exec in InCtr0; auto. contradiction.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent Cst InEv.
   - apply consistent_impl_exec in InCtr0; auto. contradiction. 
 Qed.
 Print CDS_Y2_C1.
@@ -1075,7 +1048,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -1089,12 +1062,9 @@ Proof.
         eapply pay_at_t_not_defaulted; eauto.
       * subst c'. inversion Prim.
       * subst c'. inversion Prim.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    execute_own CDSctr H5. inversion InEv.
-    apply consistent_impl_exec in InCtr0; auto. inversion H7; auto.
-    find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv.  inconsistent Cst InEv.
   - simpl in InCtr. contradiction.
 Qed.
 
@@ -1145,7 +1115,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -1159,12 +1129,9 @@ Proof.
       * eapply exec_later_no_effect; eauto.
       * subst c'. inversion Prim.
         contradict H9. omega.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    execute_own CDSctr H5. inversion InEv.
-    apply consistent_impl_exec in InCtr0; auto. inversion H7; auto.
-    find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent Cst InEv.
   - simpl in InCtr. contradiction.
 Qed.
 
@@ -1216,7 +1183,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -1233,12 +1200,9 @@ Proof.
         assert (H' : price = price + 0 * b2afee); try omega.
         rewrite H'.
         eapply yearly_checks_not_defaulted; eauto; try omega.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    execute_own CDSctr H5. inversion InEv.
-    apply consistent_impl_exec in InCtr0; auto. inversion H7; auto.
-    find_contradiction InEv.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent Cst InEv.
   - simpl in InCtr. contradiction.
 Qed.
 
@@ -1293,7 +1257,7 @@ Proof.
   induction Step; subst s2.
   - inversion_event InEv.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
-  - ctr_case_analysis CDSctr ctr. clear H8.
+  - same_ctr InEv. subst ctr.
     execute_own CDSctr H7. simpl in *.
     subst now.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
@@ -1314,11 +1278,9 @@ Proof.
         assert (H' : (price + 0 = price + 0 * b2afee)); try omega.
         rewrite H'. reflexivity.
         omega. omega.
-  - not_or ctr CDSctr H4.
-  - not_or ctr CDSctr H4.
-  - ctr_case_analysis CDSctr ctr.
-    inversion_event InEv.
-    apply consistent_impl_exec in InCtr0; auto. contradiction.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - same_ctr InEv. subst ctr. not_or' CDSctr H4.
+  - inversion_event InEv. inconsistent Cst InEv.
   - apply consistent_impl_exec in InCtr0; auto. contradiction. 
 Qed.
 Print CDS_Y3_C1.

--- a/proofs/credit_default_swap.v
+++ b/proofs/credit_default_swap.v
@@ -157,16 +157,16 @@ Lemma helper_1 :
 Proof.
   intros.
   case_eq (t + y + d <? t); intros * H'; trivial.
-  apply ltb_sound_true in H'.
+  apply leb_sound_true in H'.
   omega.
 Qed.
 
 Lemma helper_2 :
-  forall t y d,  y > d -> (t + y - d <? t) = false.
+  forall t y d,  y > d -> (t + y - d <=? t) = false.
 Proof.
   intros.
-  case_eq (t + y - d <? t); intros * H'; trivial.
-  apply ltb_sound_true in H'.
+  case_eq (t + y - d <=? t); intros * H'; trivial.
+  apply leb_sound_true in H'.
   omega.
 Qed.
 
@@ -258,7 +258,7 @@ Proof.
       * simpl. left. eauto.
       * repeat split; simpl; trivial.
         resolve_owner H0. omega.
-    + subst t. apply ltb_sound_false in H5. contradict H5.
+    + subst t. apply leb_sound_false in H5. contradict H5.
       assert (H' : m_global_time s1 > Δ).
       apply global_time_is_bigger_than_delta. 
       unfold Δ. omega.
@@ -289,7 +289,7 @@ Proof.
     + subst t.
       rewrite Q in H10. simpl in *.
       inversion H10. trivial.
-    + subst t. apply ltb_sound_false in H5. contradict H5.
+    + subst t. apply leb_sound_false in H5. contradict H5.
       assert (H' : m_global_time s1 > Δ).
       apply global_time_is_bigger_than_delta. 
       unfold Δ. omega.
@@ -367,13 +367,13 @@ Proof.
       case_match H10.
       case_if H8.
       case_if H12.
-      * apply ltb_sound_true in H8. contradict H8. omega.
+      * apply leb_sound_true in H8. contradict H8. omega.
       * destruct r. inversion H13. clear H13. subst.
         inversion H11. clear H11.
         eexists. split.
         apply in_app_iff. right. simpl. left. trivial.
         repeat split; trivial. resolve_owner H0.
-    + apply ltb_sound_false in H5. contradict H5. unfold Δ. omega.
+    + apply leb_sound_false in H5. contradict H5. unfold Δ. omega.
   - not_or c ctr H2.
   - not_or c ctr H2.
   - ctr_case_analysis c ctr. inversion_event InEv. find_contradiction InEv.
@@ -423,7 +423,7 @@ Proof.
         repeat split; auto.
         simpl. resolve_owner H0.
         simpl. omega.
-    + apply ltb_sound_false in H5. contradict H5. unfold Δ. omega.
+    + apply leb_sound_false in H5. contradict H5. unfold Δ. omega.
   - not_or c ctr H2.
   - not_or c ctr H2.
   - ctr_case_analysis c ctr. inversion_event InEv. find_contradiction InEv.
@@ -505,7 +505,7 @@ Proof.
     apply consistent_impl_exec in InCtr0; auto. contradiction.
   - ctr_case_analysis CDSctr ctr. clear H8.
     execute_own CDSctr H7. simpl in *.
-    subst now.
+    subst now. 
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
     rewrite helper_1, helper_2 in H7; unfold Δ; try auto; try omega.
     inversion H7. clear H7. subst.

--- a/proofs/external_rate_currency_exchange.v
+++ b/proofs/external_rate_currency_exchange.v
@@ -24,30 +24,29 @@ Proposition erce_I_to_O :
       tr_currency tr = USD).
 Proof.
   intros.
-  destruct H1 as [s' [Ss1 [Ss2 [E | D]]]].
+  destruct H1 as [s' [Ss1 [Ss2 [E | D]]]]; insert_consistent s Ss.
   - destruct_executed E.
-    insert_consistent s Ss.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction Ev.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H10. subst t. rewrite H3 in *.
       inversion H10. subst. clear H10.
       eexists. split.
       eapply steps_does_not_remove_transactions; eauto.
       simpl. left. trivial.
       repeat split; trivial. resolve_owner H5.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction Ev.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + inversion_event Ev. inconsistent H1 Ev.
     + find_contradiction Ev.
   - destruct_deleted D.
-    insert_consistent s Ss.
     induction St; subst s'.
-    + inversion_event Ev. find_contradiction_del Ev.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction_del Ev.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0. execute_own ctr H8.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + same_ctr_del Ev. subst ctr0.
+      execute_own ctr H8.
       subst t. rewrite H3 in *. inversion H8.
     + find_contradiction_del Ev.
 Qed.
@@ -72,31 +71,31 @@ Proposition erce_O_to_I :
       tr_currency tr = EUR).
 Proof.
   intros.
-  destruct H1 as [s' [Ss1 [Ss2 [E | D]]]].
+  destruct H1 as [s' [Ss1 [Ss2 [E | D]]]]; insert_consistent s Ss.
   - destruct_executed E.
-    insert_consistent s Ss.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction Ev.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H10. subst t. rewrite H3 in *.
       inversion H10. subst. clear H10.
       eexists. split.
       eapply steps_does_not_remove_transactions; eauto.
       simpl. right. left. trivial.
       repeat split; trivial. resolve_owner H5.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction Ev.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + inversion_event Ev. inconsistent H1 Ev.
     + find_contradiction Ev.
   - destruct_deleted D.
     insert_consistent s Ss.
     induction St; subst s'.
-    + inversion_event Ev. find_contradiction_del Ev.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction_del Ev.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0. execute_own ctr H8.
-      subst t. rewrite H3 in *. inversion H8.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + same_ctr_del Ev. subst ctr0.
+      execute_own ctr H9.
+      subst t. rewrite H3 in *. inversion H9.
     + find_contradiction_del Ev.
 Qed.
 
@@ -118,21 +117,19 @@ Proof.
   - destruct_executed E.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H6. subst t. rewrite H in *.
       inversion H6.
-    + not_or ctr ctr0 H3.
-    + not_or ctr ctr0 H3.
+    + same_ctr Ev. subst ctr0. not_or' ctr H3.
+    + same_ctr Ev. subst ctr0. not_or' ctr H3.
     + simpl. trivial.
     + simpl. trivial.
   - destruct_deleted D.
     induction St; subst s'.
-    + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
-      execute_own ctr H6. subst t. rewrite H in *.
-      inversion H6.
-    + not_or ctr ctr0 H3.
-    + not_or ctr ctr0 H3.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev. find_contradiction_del Ev.
+    + inversion_event Ev. find_contradiction_del Ev.
+    + inversion_event Ev. find_contradiction_del Ev.
     + simpl. trivial.
     + simpl. trivial.
 Qed.

--- a/proofs/fixed_rate_currency_exchange.v
+++ b/proofs/fixed_rate_currency_exchange.v
@@ -6,6 +6,8 @@ Definition frce_desc :=
      (Give (Scale 11 (One USD)))
      (Scale 10 (One EUR))
   ).
+Ltac print_numgoals := let n := numgoals in idtac "# of goals:" n.
+
 
 (* The issuer receives scale * 10 EUR from the owner (who joins) *)
 Proposition frce_I_to_O :
@@ -23,29 +25,27 @@ Proposition frce_I_to_O :
       tr_currency tr = EUR.
 Proof.
   intros.
-  destruct_join H1.
-  - insert_consistent s Ss.
-    induction St; subst s'.
-    + inversion_event Ev. find_contradiction Ev.
-    + ctr_case_analysis ctr ctr0.
+  destruct_join H1; insert_consistent s Ss.
+  - induction St; subst s'. 
+    + inversion_event Ev. inconsistent H1 Ev.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H9.
-      inversion H9.
-      eexists. split.
+      inversion H9. clear H9.
+      eexists; split.
       eapply steps_does_not_remove_transactions; eauto.
       simpl. subst ledger'. simpl. left. trivial.
-      repeat split; trivial. resolve_owner H4.
-    + not_or ctr ctr0 H6.
-    + not_or ctr ctr0 H6.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction Ev.
+        repeat split; trivial. resolve_owner H4.
+    + same_ctr Ev. subst ctr0. not_or' ctr H6.
+    + same_ctr Ev. subst ctr0. not_or' ctr H6.
+    + inversion_event Ev. inconsistent H1 Ev.
     + find_contradiction Ev.
-  - insert_consistent s Ss.
-    induction St; subst s'.
-    + inversion_event Ev. find_contradiction_del Ev.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction_del Ev.
-    + not_or ctr ctr0 H6.
-    + not_or ctr ctr0 H6.
-    + ctr_case_analysis ctr ctr0. execute_own ctr H7. inversion H7.
-    + find_contradiction_del Ev.
+  - induction St; subst s'.
+    + try inversion_event Ev; try find_contradiction_del Ev.
+    + try inversion_event Ev; try find_contradiction_del Ev.
+    + try inversion_event Ev; try find_contradiction_del Ev.
+    + try inversion_event Ev; try find_contradiction_del Ev.
+    + same_ctr_del Ev. subst ctr0. execute_own ctr H7. inversion H7.
+    + try find_contradiction_del Ev.
 Qed.
 
 Print frce_I_to_O.
@@ -67,28 +67,26 @@ Proposition frce_O_to_I :
       tr_currency tr = USD.
 Proof.
   intros.
-  destruct_join H1.
-  - insert_consistent s Ss.
-    induction St; subst s'.
-    + inversion_event Ev. find_contradiction Ev.
-    + ctr_case_analysis ctr ctr0.
+  destruct_join H1; insert_consistent s SS.
+  - induction St; subst s'.
+    + inversion_event Ev. inconsistent H1 Ev.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H9.
       inversion H9.
       eexists. split.
       eapply steps_does_not_remove_transactions; eauto.
       simpl. subst ledger'. simpl. right. left. trivial.
       repeat split; trivial. resolve_owner H4.
-    + not_or ctr ctr0 H6.
-    + not_or ctr ctr0 H6.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction Ev.
+    + same_ctr Ev. subst ctr0. not_or' ctr H6.
+    + same_ctr Ev. subst ctr0. not_or' ctr H6.
+    + inversion_event Ev. inconsistent H1 Ev.
     + find_contradiction Ev.
-  - insert_consistent s Ss.
-    induction St; subst s'.
-    + inversion_event Ev. find_contradiction_del Ev.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction_del Ev.
-    + not_or ctr ctr0 H6.
-    + not_or ctr ctr0 H6.
-    + ctr_case_analysis ctr ctr0. execute_own ctr H7. inversion H7.
+  - induction St; subst s'.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + inversion_event Ev; find_contradiction_del Ev.
+    + same_ctr_del Ev. subst ctr0. execute_own ctr H7. inversion H7.
     + find_contradiction_del Ev.
 Qed.
 

--- a/proofs/option_derivative.v
+++ b/proofs/option_derivative.v
@@ -31,13 +31,12 @@ Proof.
     + ctr_case_analysis ctr ctr0.
       execute_own ctr H10.
       case_if H10.
-      case_if H13.
       * eexists. split.
         ** eapply steps_does_not_remove_transactions; eauto.
            simpl. subst ledger'. left. eauto.
         ** repeat split; trivial. resolve_owner H5.
-      * simpl in *. rewrite <- T0 in *.
-        apply ltb_sound_false in H10. contradiction H10.
+      * simpl in *. rewrite <- T0 in *. 
+        apply ltb_sound_false in H0. contradiction H0.
     + not_or ctr ctr0 H7.
     + not_or ctr ctr0 H7.
     + inversion_event Ev. find_contradiction H.
@@ -51,10 +50,6 @@ Proof.
     + ctr_case_analysis ctr ctr0.
       execute_own ctr H8.
       case_if H8.
-      * apply ltb_sound_true in H0.
-        apply Nat.lt_asymm in H0.
-        contradict H0. apply infinite.
-      * case_if H11.
     + find_contradiction_del H.
 Qed.
 
@@ -83,30 +78,19 @@ Proof.
       execute_own ctr H12.
       case_analysis H12.
       case_analysis H15.
-      * case_analysis H16.
-        case_analysis H17; simpl in *;
-          rewrite H0, H12, H14, H15 in Exec; inversion Exec; clear Exec;
-            rewrite <- H17 in M0; simpl in M0.
-        ** destruct M0 as [M0 | M0]; try contradiction.
-           rewrite <- M0 in H2. simpl in H2. inversion H2.
-        ** destruct M0 as [M0 | [M0 | M0]]; try contradiction.
-           *** rewrite <- M0 in H2. simpl in H2. inversion H2.
-           *** eapply option_I_to_O_helper; eauto.
-               rewrite <- M0 in J.
-               rewrite <- M0. simpl.
-               exact J.
-      * case_analysis H16.
-        case_analysis H17; simpl in *;
-          rewrite H0, H12, H14, H15 in Exec; inversion Exec; clear Exec;
-            rewrite <- H17 in M0; simpl in M0.
-        ** destruct M0 as [M0 | M0]; try contradiction.
-           rewrite <- M0 in H2. simpl in H2. inversion H2.
-        ** destruct M0 as [M0 | [M0 | M0]]; try contradiction.
-           *** rewrite <- M0 in H2. simpl in H2. inversion H2.
-           *** eapply option_I_to_O_helper; eauto.
-               rewrite <- M0 in J.
-               rewrite <- M0. simpl.               
-               exact J.
+      * apply ltb_sound_false in H0.
+        apply ltb_sound_true in H12.
+        omega.
+      * simpl in *.
+        rewrite H0, H12 in Exec; inversion Exec. clear Exec.
+        subst res.
+        simpl in M0.
+        destruct M0 as [M0 | [M0 | M0]]; try contradiction.
+        ** rewrite <- M0 in H2. inversion H2.
+        ** eapply option_I_to_O_helper; eauto.
+           rewrite <- M0 in J.
+           rewrite <- M0. simpl.
+           exact J.
     + not_or ctr ctr0 H9.
     + not_or ctr ctr0 H9.
     + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
@@ -125,14 +109,6 @@ Proof.
       * unfold option_derivative in Exec. simpl in Exec.
         rewrite H0 in Exec. inversion Exec.
       * case_analysis H13.
-        ** case_analysis H14.
-           *** unfold option_derivative in Exec. simpl in Exec.
-               rewrite H0, H10, H12 in Exec. inversion Exec.
-           *** case_analysis H15.
-        ** case_analysis H15.
-           *** unfold option_derivative in Exec. simpl in Exec.
-               rewrite H0, H10, H12 in Exec. inversion Exec.
-           *** case_analysis H15.
     + find_contradiction_del M.
 Qed.
 
@@ -161,16 +137,14 @@ Proof.
       simpl in Exec.
       case_analysis H11.
       case_analysis H14. rewrite H0, H4 in *.
-      * case_analysis H15.
-        case_analysis H16; rewrite H13, H14 in *; subst res; simpl in *.
-        ** destruct M0 as [M0 | M0]; try contradiction.
-           subst gen_ctr. simpl. trivial.
-        ** destruct M0 as [M0 | [M0 | M0]]; try contradiction; try subst gen_ctr; simpl; trivial.
-      * case_analysis H15.
-        case_analysis H16; rewrite H13, H14 in *; subst res; simpl in *.
-        ** destruct M0 as [M0 | M0]; try contradiction.
-           subst gen_ctr. simpl. trivial.
-        ** destruct M0 as [M0 | [M0 | M0]]; try contradiction; try subst gen_ctr; simpl; trivial.
+      * apply ltb_sound_false in H0.
+        apply ltb_sound_true in H4.
+        omega.
+      * subst res.
+        simpl in M0.
+        destruct M0 as [M0 | [M0 | M0]]; try contradiction.
+        ** subst gen_ctr. simpl. trivial.
+        ** subst gen_ctr. simpl. trivial.
     + not_or ctr ctr0 H8.
     + not_or ctr ctr0 H8.
     + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
@@ -188,10 +162,14 @@ Proof.
       simpl in Exec.
       case_analysis H9.
       case_analysis H12; rewrite H0, H4 in *.
-      * case_analysis H13.
-        case_analysis H14; rewrite H11, H12 in *; try inversion H9.
-      * case_analysis H13.
-        case_analysis H14; rewrite H11, H12 in H9; try inversion H9.
+      * apply ltb_sound_false in H0.
+        apply ltb_sound_true in H4.
+        omega.
+      * subst res.
+        simpl in M0.
+        destruct M0 as [M0 | [M0 | M0]]; try contradiction.
+        ** subst gen_ctr. simpl. trivial.
+        ** subst gen_ctr. simpl. trivial.
     + find_contradiction_del M.
 Qed.
 
@@ -272,23 +250,17 @@ Proof.
       execute_own ctr H11.
       case_analysis H11.
       case_analysis H14.
-      * case_analysis H15.
-        case_analysis H16.
-        ** subst t. apply ltb_sound_true in H14. contradict H14. omega.
-        ** simpl in Exec. rewrite H0, H11, H13, H14 in Exec.
-           inversion Exec. subst res. simpl in *.
-           destruct M0 as [M0 | [M0 | M0]]; try contradiction.
-           *** eapply option_O_to_I_helper; eauto.
-               rewrite <- M0 in J. rewrite <- M0.
-               exact J.
-           *** rewrite <- M0 in H2. simpl in H2. inversion H2.
-      * case_analysis H15.
-        case_analysis H16.
-        ** subst t. apply ltb_sound_true in H14. contradict H14. omega.
-        ** simpl in Exec. rewrite H0, H11, H13, H14 in Exec.
-           inversion Exec. subst res. simpl in *.
-           destruct M0 as [M0 | [M0 | M0]]; try contradiction;
-             rewrite <- M0 in H2; simpl in H2; inversion H2.
+      * apply ltb_sound_false in H0.
+        apply ltb_sound_true in H11.
+        omega.
+      * simpl in Exec.
+        rewrite H0, H11 in Exec.  inversion Exec; clear Exec.
+        subst res.
+        destruct M0 as [M0 | [M0 | M0]]; try contradiction.
+        ** eapply option_O_to_I_helper; eauto.
+           rewrite <- M0 in *.
+           simpl.  exact J.
+        ** rewrite <- M0 in H2. simpl in H2. inversion H2.
     + not_or ctr ctr0 H8.
     + not_or ctr ctr0 H8.
     + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
@@ -306,14 +278,6 @@ Proof.
       case_analysis H9.
       * simpl in Exec. rewrite H0 in Exec. inversion Exec.
       * case_analysis H12.
-        ** case_analysis H13; try case_analysis H14.
-           apply ltb_sound_true in H11.
-           apply Nat.lt_asymm in H11.
-           contradict H11. eapply infinite.
-        ** case_analysis H13; try case_analysis H14.
-           apply ltb_sound_true in H11.
-           apply Nat.lt_asymm in H11.
-           contradict H11. eapply infinite.
     + find_contradiction_del M.
 Qed.
 

--- a/proofs/option_derivative.v
+++ b/proofs/option_derivative.v
@@ -28,7 +28,7 @@ Proof.
   - insert_consistent s Ss.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction H.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev.  subst ctr0.
       execute_own ctr H10.
       case_if H10.
       * eexists. split.
@@ -37,19 +37,17 @@ Proof.
         ** repeat split; trivial. resolve_owner H5.
       * simpl in *. rewrite <- T0 in *. 
         apply ltb_sound_false in H0. contradiction H0.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
     + inversion_event Ev. find_contradiction H.
     + find_contradiction H.
   - insert_consistent s Ss.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del H.
     + inversion_event Ev. find_contradiction_del H.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0.
-      execute_own ctr H8.
-      case_if H8.
+    + inversion_event Ev. find_contradiction_del H.
+    + inversion_event Ev. find_contradiction_del H.
+    + same_ctr_del Ev. subst ctr0. execute_own ctr H8. case_if H8.
     + find_contradiction_del H.
 Qed.
 
@@ -74,7 +72,7 @@ Proof.
     insert_consistent s' St.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H12.
       case_analysis H12.
       case_analysis H15.
@@ -91,9 +89,9 @@ Proof.
            rewrite <- M0 in J.
            rewrite <- M0. simpl.
            exact J.
-    + not_or ctr ctr0 H9.
-    + not_or ctr ctr0 H9.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H9.
+    + same_ctr Ev. subst ctr0. not_or' ctr H9.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - insert_consistent s Ss.
     destruct_deleted D.
@@ -101,9 +99,9 @@ Proof.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
     + inversion_event Ev. find_contradiction_del M.
-    + not_or ctr ctr0 H9.
-    + not_or ctr ctr0 H9.
-    + ctr_case_analysis ctr ctr0.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0.
       execute_own ctr H10.
       case_analysis H10.
       * unfold option_derivative in Exec. simpl in Exec.
@@ -131,7 +129,7 @@ Proof.
     insert_consistent s Ss1.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H11.
       destruct_generates H4.
       simpl in Exec.
@@ -145,18 +143,18 @@ Proof.
         destruct M0 as [M0 | [M0 | M0]]; try contradiction.
         ** subst gen_ctr. simpl. trivial.
         ** subst gen_ctr. simpl. trivial.
-    + not_or ctr ctr0 H8.
-    + not_or ctr ctr0 H8.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H8.
+    + same_ctr Ev. subst ctr0. not_or' ctr H8.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - destruct_deleted D.
     insert_consistent s Ss1.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
     + inversion_event Ev. find_contradiction_del M.
-    + not_or ctr ctr0 H8.
-    + not_or ctr ctr0 H8.
-    + ctr_case_analysis ctr ctr0.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0.
       execute_own ctr H9.
       destruct_generates H4.
       simpl in Exec.
@@ -196,8 +194,8 @@ Proof.
     insert_consistent s' St.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0. subst ctr. simpl in H7. contradiction.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0 ctr. simpl in H7. contradiction.
+    + same_ctr Ev. subst ctr0.
       rewrite H0 in H10, H7. simpl in H7. inversion H7.
       unfold exec_prim_ctr_in_state_with_owner in H10.
       subst c1 c2. simpl in H10. inversion H10.
@@ -205,7 +203,7 @@ Proof.
       * eapply steps_does_not_remove_transactions; eauto.
         subst ledger'. simpl. left. trivial.
       * repeat split; trivial. resolve_owner H5.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       rewrite H0 in H10, H7. simpl in H7. inversion H7.
       unfold exec_prim_ctr_in_state_with_owner in H10.
       subst c1 c2. simpl in H10. inversion H10.
@@ -213,16 +211,16 @@ Proof.
       * eapply steps_does_not_remove_transactions; eauto.
         subst ledger'. simpl. left. trivial.
       * repeat split; trivial. resolve_owner H5.
-    + ctr_case_analysis ctr ctr0. execute_own ctr H8. inversion H8.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - insert_consistent s Ss.
     insert_consistent s' St.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
-    + ctr_case_analysis ctr ctr0. subst ctr. simpl in H7. contradiction.
-    + simpl in Ev. inversion_event Ev. find_contradiction_del M.
-    + simpl in Ev. inversion_event Ev. find_contradiction_del M.
-    + ctr_case_analysis ctr ctr0. execute_own ctr H8. inversion H8.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0. execute_own ctr H8. inversion H8.
     + find_contradiction_del M.
 Qed.
 
@@ -246,7 +244,7 @@ Proof.
     insert_consistent s' St.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst  ctr0.
       execute_own ctr H11.
       case_analysis H11.
       case_analysis H14.
@@ -261,9 +259,9 @@ Proof.
            rewrite <- M0 in *.
            simpl.  exact J.
         ** rewrite <- M0 in H2. simpl in H2. inversion H2.
-    + not_or ctr ctr0 H8.
-    + not_or ctr ctr0 H8.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst  ctr0. not_or' ctr H8.
+    + same_ctr Ev. subst  ctr0. not_or' ctr H8.
+    + inversion_event Ev.  find_contradiction M.
     + find_contradiction M.
   - insert_consistent s Ss.
     destruct_deleted D.
@@ -271,9 +269,9 @@ Proof.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
     + inversion_event Ev. find_contradiction_del M.
-    + not_or ctr ctr0 H8.
-    + not_or ctr ctr0 H8.
-    + ctr_case_analysis ctr ctr0.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0.
       execute_own ctr H9.
       case_analysis H9.
       * simpl in Exec. rewrite H0 in Exec. inversion Exec.

--- a/proofs/zero_coupon_bond.v
+++ b/proofs/zero_coupon_bond.v
@@ -25,11 +25,10 @@ Proposition zcb_O_to_I:
       tr_amount tr = sc * 10.
 Proof.
   intros.
-  destruct_join H1.
-  - insert_consistent s Ss.
-    induction St; subst s'.
+  destruct_join H1; insert_consistent s Ss.
+  - induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H9.
       case_analysis H9.
       case_analysis H12.
@@ -41,22 +40,19 @@ Proof.
         ** eapply steps_does_not_remove_transactions; eauto.
            simpl. subst ledger'. left. eauto.
         ** repeat split; trivial. resolve_owner H4.
-    + not_or ctr ctr0 H6.
-    + not_or ctr ctr0 H6.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H6.
+    + same_ctr Ev. subst ctr0. not_or' ctr H6.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
-  - insert_consistent s Ss.
-    induction St; subst s'.
+  - induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
-    + ctr_case_analysis ctr ctr0.
-      inversion_event Ev. find_contradiction_del M.
-    + not_or ctr ctr0 H6.
-    + not_or ctr ctr0 H6.
-    + ctr_case_analysis ctr ctr0.
-      execute_own ctr H7.
-      case_analysis H7; simpl in *; rewrite <- T in *.
-      * eapply ltb_sound_true in H0. contradict H0. omega.
-      * case_analysis H10.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0. execute_own ctr H7.
+      case_analysis H7.
+      * apply ltb_sound_true in H0. omega.
+      * case_analysis H9.
     + find_contradiction_del M.
 Qed.
 
@@ -80,32 +76,28 @@ Lemma inner_ctr_proof:
       tr_amount tr = sc * 11.
 Proof.
   intros.
-  destruct_join H1.
-  - insert_consistent s Ss.
-    induction St; subst s'.
+  destruct_join H1; insert_consistent s Ss.
+  - induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H10.
       case_if H10.
-      case_if H14.
+      case_if H12.
       * eexists. split.
         ** eapply steps_does_not_remove_transactions; eauto.
            subst ledger'. simpl. left. eauto.
       ** repeat split; trivial. resolve_owner H5.
       * eapply leb_sound_false in H10. contradict H10. rewrite <- T. unfold Δ. omega.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + same_ctr Ev. subst ctr0. not_or' ctr H7.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
-  - insert_consistent s Ss.
-    induction St; subst s'.
+  - induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
-    + ctr_case_analysis ctr ctr0.
-       inversion_event Ev. find_contradiction_del M.
-    + not_or ctr ctr0 H7.
-    + not_or ctr ctr0 H7.
-    + ctr_case_analysis ctr ctr0.
-      execute_own ctr H8.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0. execute_own ctr H8.
       case_if H8; simpl in *.
       * rewrite <- T in H0. apply ltb_sound_true in H0. contradict H0. omega.
       * case_if H11.
@@ -131,11 +123,10 @@ Proof.
     insert_consistent s' St.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
-      simpl in Ev. inversion_event Ev.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H11.
       case_analysis H11.
-      case_analysis H15.
+      case_analysis H13.
       * eexists. split.
         eapply steps_does_not_remove_transactions. exact Ss0.
         subst ledger'. simpl. left. eauto.
@@ -160,9 +151,9 @@ Proof.
            repeat split; simpl in *; auto.
            right. unfold executed. repeat split; trivial;
            simpl; subst gen_ctr; try exact M1; simpl; auto.
-    + not_or ctr ctr0 H8.
-    + not_or ctr ctr0 H8.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H8.
+    + same_ctr Ev. subst ctr0. not_or' ctr H8.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - destruct_deleted D.
     insert_consistent s Ss.
@@ -170,15 +161,12 @@ Proof.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M0.
     + inversion_event Ev. find_contradiction_del M0.
-    + not_or ctr ctr0 H8.
-    + not_or ctr ctr0 H8.
-    + ctr_case_analysis ctr ctr0.
-      inversion_event Ev.
-      * execute_own ctr H9.
-        case_analysis H9.
-        ** simpl in *. rewrite H0 in Exec. inversion Exec.
+    + inversion_event Ev. find_contradiction_del M0.
+    + inversion_event Ev. find_contradiction_del M0.
+    + same_ctr_del Ev. subst ctr0. execute_own ctr H9.
+      * case_analysis H9.
+        ** simpl in *. rewrite  H0 in Exec. inversion Exec.
         ** case_analysis H12.
-      * find_contradiction_del M0.
     + find_contradiction_del M0.
 Qed.
 
@@ -202,14 +190,14 @@ Proof.
   - insert_consistent s Ss.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0. 
       execute_own ctr H11.
       simpl in *.
       case_if H11.
       case_if H14; rewrite T0 in *; apply ltb_sound_false in H0; contradict H0; omega.
-    + not_or ctr ctr0 H8.
-    + not_or ctr ctr0 H8.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H8.
+    + same_ctr Ev. subst ctr0. not_or' ctr H8.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - eapply steps_does_not_remove_events; eauto.
 Qed.
@@ -231,7 +219,7 @@ Proof.
     insert_consistent s' Ss.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction M.
-    + ctr_case_analysis ctr ctr0.
+    + same_ctr Ev. subst ctr0.
       execute_own ctr H12.
       case_analysis H12.
       case_analysis H15.
@@ -244,9 +232,9 @@ Proof.
         inversion Exec. subst res.
         simpl in M0, J. destruct M0 as [M0 | M0]; try contradiction.
         eapply O_joins_generated_too_late_inner; eauto.
-    + not_or ctr ctr0 H9.
-    + not_or ctr ctr0 H9.
-    + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
+    + same_ctr Ev. subst ctr0. not_or' ctr H9.
+    + same_ctr Ev. subst ctr0. not_or' ctr H9.
+    + inversion_event Ev. find_contradiction M.
     + find_contradiction M.
   - destruct_deleted D.
     insert_consistent s Ss.
@@ -254,15 +242,13 @@ Proof.
     induction St; subst s'.
     + inversion_event Ev. find_contradiction_del M.
     + inversion_event Ev. find_contradiction_del M.
-    + not_or ctr ctr0 H9.
-    + not_or ctr ctr0 H9.
-    + ctr_case_analysis ctr ctr0.
-      inversion_event Ev.
-      * execute_own ctr H10.
-        case_analysis H10.
-        ** simpl in *. rewrite H0 in Exec. inversion Exec.
-        ** case_analysis H13.
-      * find_contradiction_del M0.
+    + inversion_event Ev. find_contradiction_del M.
+    + inversion_event Ev. find_contradiction_del M.
+    + same_ctr_del Ev. subst ctr0.
+      execute_own ctr H10.
+      case_analysis H10.
+      * simpl in *. rewrite H0 in Exec. inversion Exec.
+      * case_analysis H13.
     + find_contradiction_del M0.
 Qed.
 

--- a/proofs/zero_coupon_bond.v
+++ b/proofs/zero_coupon_bond.v
@@ -92,7 +92,7 @@ Proof.
         ** eapply steps_does_not_remove_transactions; eauto.
            subst ledger'. simpl. left. eauto.
       ** repeat split; trivial. resolve_owner H5.
-      * eapply ltb_sound_false in H10. contradict H10. rewrite <- T. unfold Δ. omega.
+      * eapply leb_sound_false in H10. contradict H10. rewrite <- T. unfold Δ. omega.
     + not_or ctr ctr0 H7.
     + not_or ctr ctr0 H7.
     + ctr_case_analysis ctr ctr0. inversion_event Ev. find_contradiction M.
@@ -236,7 +236,7 @@ Proof.
       case_analysis H12.
       case_analysis H15.
       * rewrite <- T0 in *.
-        apply ltb_sound_true in H12.
+        apply leb_sound_true in H12.
         apply ltb_sound_false in H0.
         contradict H0. unfold Δ. omega.
       * simpl in *. 

--- a/src/findel.v
+++ b/src/findel.v
@@ -18,18 +18,7 @@ Inductive Currency :=
 | CNY  : Currency
 | SGD  : Currency
 | NONE : Currency.
-Definition beq_currency (c c' : Currency) :=
-  match c, c' with
-  | USD , USD  => true
-  | EUR , EUR  => true
-  | GBP , GBP  => true
-  | JPY , JPY  => true
-  | CNY , CNY  => true
-  | SGD , SGD  => true
-  | NONE, NONE => true
-  | _, _ => false
-  end.
-
+Scheme Equality for Currency.
 
 Definition Address := nat. (* convention: 0 stands for 0x0 *)
 Definition Time := nat.
@@ -37,12 +26,22 @@ Inductive TimeInterval :=
 | interval : nat -> nat -> TimeInterval
 | after : nat -> TimeInterval
 | before : nat -> TimeInterval.
+Scheme Equality for TimeInterval.
+
+Open Scope bool_scope.
+Definition interval_eq_dec (i1 i2 : TimeInterval) :=
+  match i1, i2 with
+  | interval t0 t1, interval t0' t1' => (t0 =? t0') && (t1 =? t1')
+  | after t, after t' => t =? t'
+  | before t, before t' => t =? t'
+  | _, _ => false
+  end.
 
 Definition Balance := Address -> Currency -> Z.
 Definition update (balance : Balance) (a : Address)
            (c : Currency) (amount : Z): Balance :=
   fun (x : Address) (y : Currency) =>
-    if (andb (Nat.eqb x a) (beq_currency c y))
+    if (andb (Nat.eqb x a) (Currency_beq c y))
     then amount
     else (balance x y).
 
@@ -59,7 +58,9 @@ Inductive Primitive :=
 | Or        : Primitive -> Primitive ->            Primitive
 | If        : Address -> Primitive -> Primitive -> Primitive
 | Timebound : TimeInterval -> Primitive ->         Primitive.
+Scheme Equality for Primitive.
 
+(* derived syntax *)
 Definition At (t : nat) (p : Primitive) := Timebound (interval (t - Δ) (t + Δ)) p.
 Definition Before (t : nat) (p : Primitive) := Timebound (before t) p.
 Definition After (t : nat) (p : Primitive) := Timebound (after t) p.
@@ -122,6 +123,9 @@ Record FinContract :=
       ctr_proposed_owner : Address;
       ctr_scale : nat;
     }.
+Scheme Equality for FinContract.
+
+
 Record Result :=
   result {
       res_balance : Balance;
@@ -271,14 +275,12 @@ A Findel contract has the following execution model~\cite{findel}:
 
 3. The execution of a contract -- more precisely, the execution of its corresponding primitive -- either has an effect on the balance of the participants, or it issues new contracts. In the Coq semantics, we use the function {\tt execute\_primitive} to execute a primitive.
 
-*)
-
-Axiom ctr_eq_dec : forall c c' : FinContract, {c = c'} + {c <> c}.
+ *)
 
 Fixpoint rm (c : FinContract) (l : list FinContract) :=
   match l with
   | [] => []
-  | (c' :: l) => if ctr_eq_dec c c'
+  | (c' :: l) => if FinContract_eq_dec c c'
                  then (rm c l)
                  else c' :: (rm c l)
   end.

--- a/src/findel.v
+++ b/src/findel.v
@@ -46,7 +46,7 @@ Definition update (balance : Balance) (a : Address)
     then amount
     else (balance x y).
 
-
+Scheme Equality for TimeInterval.
 Inductive Primitive :=
 (* basic primitives *)
 | Zero      :                                      Primitive
@@ -59,7 +59,7 @@ Inductive Primitive :=
 | Or        : Primitive -> Primitive ->            Primitive
 | If        : Address -> Primitive -> Primitive -> Primitive
 | Timebound : TimeInterval -> Primitive ->         Primitive.
-
+Scheme Equality for Primitive.
 Definition At (t : nat) (p : Primitive) := Timebound (interval (t - Δ) (t + Δ)) p.
 Definition Before (t : nat) (p : Primitive) := Timebound (before t) p.
 Definition After (t : nat) (p : Primitive) := Timebound (after t) p.
@@ -273,7 +273,10 @@ A Findel contract has the following execution model~\cite{findel}:
 
 *)
 
-Axiom ctr_eq_dec : forall c c' : FinContract, {c = c'} + {c <> c}.
+Definition ctr_eq_dec : forall c c' : FinContract, {c = c'} + {c <> c'}.
+Proof.
+  decide equality; try decide equality; try decide equality; try decide equality.
+Qed.
 
 Fixpoint rm (c : FinContract) (l : list FinContract) :=
   match l with

--- a/src/findel.v
+++ b/src/findel.v
@@ -7,8 +7,6 @@ Scheme Equality for list.
 
 
 Definition Δ := 30.
-Parameter INF : nat.
-Axiom infinite : forall n, n < INF.
 Definition FRESHNESS := 2.
 
 
@@ -35,6 +33,10 @@ Definition beq_currency (c c' : Currency) :=
 
 Definition Address := nat. (* convention: 0 stands for 0x0 *)
 Definition Time := nat.
+Inductive TimeInterval :=
+| interval : nat -> nat -> TimeInterval
+| after : nat -> TimeInterval
+| before : nat -> TimeInterval.
 
 Definition Balance := Address -> Currency -> Z.
 Definition update (balance : Balance) (a : Address)
@@ -56,11 +58,11 @@ Inductive Primitive :=
 | And       : Primitive -> Primitive ->            Primitive
 | Or        : Primitive -> Primitive ->            Primitive
 | If        : Address -> Primitive -> Primitive -> Primitive
-| Timebound : nat -> nat -> Primitive ->           Primitive.
+| Timebound : TimeInterval -> Primitive ->         Primitive.
 
-Definition At (t : nat) (p : Primitive) := Timebound (t - Δ) (t + Δ) p.
-Definition Before (t : nat) (p : Primitive) := Timebound 0 t p.
-Definition After (t : nat) (p : Primitive) := Timebound t INF p.
+Definition At (t : nat) (p : Primitive) := Timebound (interval (t - Δ) (t + Δ)) p.
+Definition Before (t : nat) (p : Primitive) := Timebound (before t) p.
+Definition After (t : nat) (p : Primitive) := Timebound (after t) p.
 Definition Sell (n : nat) (c : Currency) (p : Primitive)
   := And (Give (Scale n (One c))) p.
 
@@ -187,14 +189,23 @@ Fixpoint execute
       then (execute c2 scale I O balance time gtw ctr_id dsc_id nextId ledger)
       else (execute c1 scale I O balance time gtw ctr_id dsc_id nextId ledger)
     end
-  | Timebound t0 t1 p =>
+  | Timebound (interval t0 t1) p =>
     if (t1 <? time)
     then None
     else
       if (t0 <? time)
       then (execute p scale I O balance time gtw ctr_id dsc_id nextId ledger)
       else Some (result balance
-                        [(finctr (S nextId) dsc_id (Timebound t0 t1 p) I O O scale)] (S (S nextId)) ledger)
+                        [(finctr (S nextId) dsc_id (Timebound (interval t0 t1) p) I O O scale)] (S (S nextId)) ledger)
+  | Timebound (before t0) p =>
+    if (t0 <? time)
+    then None
+    else (execute p scale I O balance time gtw ctr_id dsc_id nextId ledger)
+  | Timebound (after t0) p =>
+    if (t0 <? time)
+    then (execute p scale I O balance time gtw ctr_id dsc_id nextId ledger)
+    else Some (result balance
+                        [(finctr (S nextId) dsc_id (Timebound (after t0) p) I O O scale)] (S (S nextId)) ledger)
   | Or c1 c2 =>
     Some (result balance
                  [(finctr (S nextId) dsc_id (Or c1 c2) I O O scale)] (S (S nextId)) ledger)
@@ -288,7 +299,7 @@ Definition is_or  (primitive: Primitive):=
 
 Definition is_timebound  (primitive: Primitive):=
   match primitive with
-  | Timebound _ _ _ => True
+  | Timebound _ _ => True
   | _ => False
   end.
 

--- a/src/findel.v
+++ b/src/findel.v
@@ -193,7 +193,7 @@ Fixpoint execute
     if (t1 <? time)
     then None
     else
-      if (t0 <? time)
+      if (t0 <=? time)
       then (execute p scale I O balance time gtw ctr_id dsc_id nextId ledger)
       else Some (result balance
                         [(finctr (S nextId) dsc_id (Timebound (interval t0 t1) p) I O O scale)] (S (S nextId)) ledger)

--- a/src/metaproperties.v
+++ b/src/metaproperties.v
@@ -41,7 +41,7 @@ Ltac resolve_owner H :=
 
 
 Ltac ctr_case_analysis ctr ctr' :=
-  case_eq (FinContract_eq_dec ctr ctr'); intros; try contradiction; subst ctr'.
+  case_eq (ctr_eq_dec ctr ctr'); intros; try contradiction; subst ctr'.
 
 Ltac destruct_executed H :=
   let S := fresh "St" in
@@ -472,10 +472,8 @@ Lemma rm_in:
   forall cs c, In c (rm c cs) -> False.
 Proof.
   induction cs; intros; simpl in *; try contradiction.
-  case_eq (FinContract_eq_dec c a); intros H0 H'; rewrite H' in H.
-  + eapply IHcs. eauto.
-  + simpl in H. destruct H as [H | H]. subst. contradiction.
-    eapply IHcs. eauto.
+  case_eq (ctr_eq_dec c a); intros H0 H'; rewrite H' in H; try contradiction.
+  subst c. eapply IHcs; eauto.
 Qed.
 
 
@@ -512,19 +510,6 @@ Proof.
       eapply IHP; eauto.
 Qed.
 
-Lemma incl_rm : forall S x y, x <> y -> In x (rm y S) -> In x S.
-Proof.
-  induction S.
-  - simpl.intros. trivial.
-  - intros.
-    simpl in H0.
-    case_eq (FinContract_eq_dec y a); intros He H'; rewrite H' in H0. subst.
-    + simpl. right. eapply IHS; eauto.
-    + simpl in H0. destruct H0 as [H0 | H0]; subst.
-      * simpl. left. reflexivity.
-      * simpl. right. eapply IHS; eauto.
-Qed.
-  
 
 Lemma step_preserves_consistent_state_1:
   forall s s',
@@ -539,28 +524,7 @@ Proof.
   - destruct H1 as [H1 | H1].
     + subst. simpl in *. omega.
     + apply H0 in H1. omega.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros.
-    + subst.
-      apply in_app_iff in H1.
-      destruct H1 as [H1 | H1].
-      * exfalso. eapply rm_in. exact H1.
-      * apply execute_produces_new_ids in H7.
-        apply H0 in H. omega.
-    + apply in_app_iff in H1.
-      destruct H1 as [H1 | H1].
-      * apply incl_rm in H1; auto.
-        apply H0 in H1.
-        apply execute_produces_new_ids in H7.
-        omega.
-      * apply execute_produces_new_ids in H7.
-
-
-
-    case_eq (FinContract_eq_dec ctr ctr0); intros.
-    + admit.
-    + 
-
-    try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     apply in_app_iff in H1.
     destruct H1 as [H1 | H1].
@@ -568,12 +532,7 @@ Proof.
     + apply execute_produces_new_ids in H7.
       apply H0 in H.
       omega.
-    + apply H0 in H.
-      apply in_app_iff in H.
-      destruct H1 as [H1 | H1].
-      * exfalso. eapply rm_in. exact H1.
-      
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     apply in_app_iff in H1.
     destruct H1 as [H1 | H1].
@@ -581,7 +540,7 @@ Proof.
     + apply execute_produces_new_ids in H7.
       apply H0 in H.
       omega.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     apply in_app_iff in H1.
     destruct H1 as [H1 | H1].
@@ -589,7 +548,7 @@ Proof.
     + apply execute_produces_new_ids in H7.
       apply H0 in H.
       omega.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0. auto.
 Qed.
 
@@ -635,8 +594,8 @@ Qed.
 
 
 Ltac case_eq_dec_ctr c1 c2 c :=
-  case_eq (FinContract_eq_dec c1 c); intros; try contradiction;
-  case_eq (FinContract_eq_dec c2 c); intros; try contradiction;
+  case_eq (ctr_eq_dec c1 c); intros; try contradiction;
+  case_eq (ctr_eq_dec c2 c); intros; try contradiction;
   subst c1 c2; trivial.
 
 Lemma step_preserves_consistent_state_3:
@@ -736,7 +695,7 @@ Proof.
          apply He; right. trivial.
          omega.
       ++ apply T in H1. destruct H1 as [_ H1]. contradiction.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     unfold not; split; intros.
     + destruct H9 as [H9 | H9]; try contradiction.
@@ -750,7 +709,7 @@ Proof.
     + destruct H9 as [H9 | H9]; try inversion H9.
       apply T in H.
       destruct H as [_ H]; try contradiction.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     unfold not; split; intros.
     + destruct H9 as [ | H9].
@@ -766,7 +725,7 @@ Proof.
     + destruct H9 as [H9 | H9]; try inversion H9.
       apply T in H.
       destruct H as [_ H]; try contradiction.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     unfold not; split; intros.
     + destruct H9 as [ | H9].
@@ -782,7 +741,7 @@ Proof.
     + destruct H9 as [H9 | H9]; try inversion H9.
       apply T in H.
       destruct H as [_ H]; try contradiction.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     split; unfold not; intros; eapply rm_in; eauto.
   - apply T; auto.
@@ -901,13 +860,13 @@ Proof.
     apply H'' in H1.
     destruct H1 as [H1 H1'].
     contradiction.
-  - case_eq (FinContract_eq_dec c ctr); intros.
+  - case_eq (ctr_eq_dec c ctr); intros.
     + subst. simpl. left. left. trivial.
     + contradiction.
-  - case_eq (FinContract_eq_dec c ctr); intros.
+  - case_eq (ctr_eq_dec c ctr); intros.
     + subst. simpl. left. left. trivial.
     + contradiction.
-  - case_eq (FinContract_eq_dec c ctr); intros.
+  - case_eq (ctr_eq_dec c ctr); intros.
     + subst. simpl. left. left. trivial.
     + contradiction.
   - simpl. right. unfold not. intros.
@@ -946,16 +905,16 @@ Proof.
   - left. unfold append_new_ctr_to_state in H4.
     subst s'. simpl. right. trivial.
   - subst s'. simpl.
-    case_eq (FinContract_eq_dec ctr0 ctr); intros.
+    case_eq (ctr_eq_dec ctr0 ctr); intros.
     + subst ctr0. right. left. left. trivial.
     + contradiction.
-  - case_eq (FinContract_eq_dec ctr0 ctr); intros.
+  - case_eq (ctr_eq_dec ctr0 ctr); intros.
     + subst. right. left. simpl. left. trivial.
     + contradiction.
-  - case_eq (FinContract_eq_dec ctr0 ctr); intros.
+  - case_eq (ctr_eq_dec ctr0 ctr); intros.
     + subst. right. left. simpl. left. trivial.
     + contradiction.
-  - case_eq (FinContract_eq_dec ctr0 ctr); intros.
+  - case_eq (ctr_eq_dec ctr0 ctr); intros.
     + subst. right. right. simpl. left. trivial.
     + contradiction.
   - subst s'. simpl. left. trivial.
@@ -1103,20 +1062,20 @@ Proof.
     apply H5 in H6.
     destruct H6 as [H6 _].
     contradiction.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst.
     unfold exec_ctr_in_state_with_owner in H5.
     unfold can_join in H0.
     destruct H0 as [H0 | H0].
     + eexists. eexists. subst. exact H5.
     + exists owner. eexists; eauto.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst. rewrite H2. simpl. eexists; eexists; eauto.
     Unshelve. apply owner.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     subst. rewrite H2. simpl. eexists. eexists. eauto.
     Unshelve. apply owner.
-  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
     destruct H7 as [H7 | H7]; try inversion H7.
     destruct H5 as [_ [_ [_[H5 _]]]].
     apply H5 in H.

--- a/src/metaproperties.v
+++ b/src/metaproperties.v
@@ -41,7 +41,7 @@ Ltac resolve_owner H :=
 
 
 Ltac ctr_case_analysis ctr ctr' :=
-  case_eq (ctr_eq_dec ctr ctr'); intros; try contradiction; subst ctr'.
+  case_eq (FinContract_eq_dec ctr ctr'); intros; try contradiction; subst ctr'.
 
 Ltac destruct_executed H :=
   let S := fresh "St" in
@@ -472,8 +472,10 @@ Lemma rm_in:
   forall cs c, In c (rm c cs) -> False.
 Proof.
   induction cs; intros; simpl in *; try contradiction.
-  case_eq (ctr_eq_dec c a); intros H0 H'; rewrite H' in H; try contradiction.
-  subst c. eapply IHcs; eauto.
+  case_eq (FinContract_eq_dec c a); intros H0 H'; rewrite H' in H.
+  + eapply IHcs. eauto.
+  + simpl in H. destruct H as [H | H]. subst. contradiction.
+    eapply IHcs. eauto.
 Qed.
 
 
@@ -510,6 +512,19 @@ Proof.
       eapply IHP; eauto.
 Qed.
 
+Lemma incl_rm : forall S x y, x <> y -> In x (rm y S) -> In x S.
+Proof.
+  induction S.
+  - simpl.intros. trivial.
+  - intros.
+    simpl in H0.
+    case_eq (FinContract_eq_dec y a); intros He H'; rewrite H' in H0. subst.
+    + simpl. right. eapply IHS; eauto.
+    + simpl in H0. destruct H0 as [H0 | H0]; subst.
+      * simpl. left. reflexivity.
+      * simpl. right. eapply IHS; eauto.
+Qed.
+  
 
 Lemma step_preserves_consistent_state_1:
   forall s s',
@@ -524,7 +539,28 @@ Proof.
   - destruct H1 as [H1 | H1].
     + subst. simpl in *. omega.
     + apply H0 in H1. omega.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros.
+    + subst.
+      apply in_app_iff in H1.
+      destruct H1 as [H1 | H1].
+      * exfalso. eapply rm_in. exact H1.
+      * apply execute_produces_new_ids in H7.
+        apply H0 in H. omega.
+    + apply in_app_iff in H1.
+      destruct H1 as [H1 | H1].
+      * apply incl_rm in H1; auto.
+        apply H0 in H1.
+        apply execute_produces_new_ids in H7.
+        omega.
+      * apply execute_produces_new_ids in H7.
+
+
+
+    case_eq (FinContract_eq_dec ctr ctr0); intros.
+    + admit.
+    + 
+
+    try contradiction.
     subst ctr0.
     apply in_app_iff in H1.
     destruct H1 as [H1 | H1].
@@ -532,7 +568,12 @@ Proof.
     + apply execute_produces_new_ids in H7.
       apply H0 in H.
       omega.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+    + apply H0 in H.
+      apply in_app_iff in H.
+      destruct H1 as [H1 | H1].
+      * exfalso. eapply rm_in. exact H1.
+      
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     apply in_app_iff in H1.
     destruct H1 as [H1 | H1].
@@ -540,7 +581,7 @@ Proof.
     + apply execute_produces_new_ids in H7.
       apply H0 in H.
       omega.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     apply in_app_iff in H1.
     destruct H1 as [H1 | H1].
@@ -548,7 +589,7 @@ Proof.
     + apply execute_produces_new_ids in H7.
       apply H0 in H.
       omega.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0. auto.
 Qed.
 
@@ -594,8 +635,8 @@ Qed.
 
 
 Ltac case_eq_dec_ctr c1 c2 c :=
-  case_eq (ctr_eq_dec c1 c); intros; try contradiction;
-  case_eq (ctr_eq_dec c2 c); intros; try contradiction;
+  case_eq (FinContract_eq_dec c1 c); intros; try contradiction;
+  case_eq (FinContract_eq_dec c2 c); intros; try contradiction;
   subst c1 c2; trivial.
 
 Lemma step_preserves_consistent_state_3:
@@ -695,7 +736,7 @@ Proof.
          apply He; right. trivial.
          omega.
       ++ apply T in H1. destruct H1 as [_ H1]. contradiction.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     unfold not; split; intros.
     + destruct H9 as [H9 | H9]; try contradiction.
@@ -709,7 +750,7 @@ Proof.
     + destruct H9 as [H9 | H9]; try inversion H9.
       apply T in H.
       destruct H as [_ H]; try contradiction.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     unfold not; split; intros.
     + destruct H9 as [ | H9].
@@ -725,7 +766,7 @@ Proof.
     + destruct H9 as [H9 | H9]; try inversion H9.
       apply T in H.
       destruct H as [_ H]; try contradiction.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     unfold not; split; intros.
     + destruct H9 as [ | H9].
@@ -741,7 +782,7 @@ Proof.
     + destruct H9 as [H9 | H9]; try inversion H9.
       apply T in H.
       destruct H as [_ H]; try contradiction.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst ctr0.
     split; unfold not; intros; eapply rm_in; eauto.
   - apply T; auto.
@@ -860,13 +901,13 @@ Proof.
     apply H'' in H1.
     destruct H1 as [H1 H1'].
     contradiction.
-  - case_eq (ctr_eq_dec c ctr); intros.
+  - case_eq (FinContract_eq_dec c ctr); intros.
     + subst. simpl. left. left. trivial.
     + contradiction.
-  - case_eq (ctr_eq_dec c ctr); intros.
+  - case_eq (FinContract_eq_dec c ctr); intros.
     + subst. simpl. left. left. trivial.
     + contradiction.
-  - case_eq (ctr_eq_dec c ctr); intros.
+  - case_eq (FinContract_eq_dec c ctr); intros.
     + subst. simpl. left. left. trivial.
     + contradiction.
   - simpl. right. unfold not. intros.
@@ -905,16 +946,16 @@ Proof.
   - left. unfold append_new_ctr_to_state in H4.
     subst s'. simpl. right. trivial.
   - subst s'. simpl.
-    case_eq (ctr_eq_dec ctr0 ctr); intros.
+    case_eq (FinContract_eq_dec ctr0 ctr); intros.
     + subst ctr0. right. left. left. trivial.
     + contradiction.
-  - case_eq (ctr_eq_dec ctr0 ctr); intros.
+  - case_eq (FinContract_eq_dec ctr0 ctr); intros.
     + subst. right. left. simpl. left. trivial.
     + contradiction.
-  - case_eq (ctr_eq_dec ctr0 ctr); intros.
+  - case_eq (FinContract_eq_dec ctr0 ctr); intros.
     + subst. right. left. simpl. left. trivial.
     + contradiction.
-  - case_eq (ctr_eq_dec ctr0 ctr); intros.
+  - case_eq (FinContract_eq_dec ctr0 ctr); intros.
     + subst. right. right. simpl. left. trivial.
     + contradiction.
   - subst s'. simpl. left. trivial.
@@ -1062,20 +1103,20 @@ Proof.
     apply H5 in H6.
     destruct H6 as [H6 _].
     contradiction.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst.
     unfold exec_ctr_in_state_with_owner in H5.
     unfold can_join in H0.
     destruct H0 as [H0 | H0].
     + eexists. eexists. subst. exact H5.
     + exists owner. eexists; eauto.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst. rewrite H2. simpl. eexists; eexists; eauto.
     Unshelve. apply owner.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     subst. rewrite H2. simpl. eexists. eexists. eauto.
     Unshelve. apply owner.
-  - case_eq (ctr_eq_dec ctr ctr0); intros; try contradiction.
+  - case_eq (FinContract_eq_dec ctr ctr0); intros; try contradiction.
     destruct H7 as [H7 | H7]; try inversion H7.
     destruct H5 as [_ [_ [_[H5 _]]]].
     apply H5 in H.

--- a/src/metaproperties.v
+++ b/src/metaproperties.v
@@ -352,10 +352,16 @@ Proof.
     case_eq (n =? 0); intros H'; rewrite H' in H2.
     + eapply IHP2; eauto.
     + eapply IHP1; eauto.
-  - case_if H1.
-    case_if H2.
-    + eapply IHP; eauto.
-    + exists []. simpl; auto.
+  - destruct t.
+    + case_if H1.
+      case_if H2.
+      * eapply IHP; eauto.
+      * exists []. simpl; auto.
+    + case_if H1.
+      * eapply IHP; eauto.
+      * exists []. simpl; auto.
+    + case_if H1.
+      eapply IHP; eauto.
 Qed.
 
 (* execute does not remove transactions from the ledger *)
@@ -495,10 +501,13 @@ Proof.
     case_eq (n =? 0); intros H0; rewrite H0 in H2.
     + eapply IHP2; eauto.
     + eapply IHP1; eauto.
-  - case_if H1.
-    case_if H2.
-    + eapply IHP; eauto.
-    + subst. omega.
+  - destruct t.
+    case_if H1.
+    case_if H2; try omega; try eapply IHP; eauto.
+    + case_if H1; try omega.
+      eapply IHP; eauto.
+    + case_if H1.
+      eapply IHP; eauto.
 Qed.
 
 
@@ -646,13 +655,18 @@ Proof.
     case_if H4.
     + eapply IHP2; eauto.
     + eapply IHP1; eauto.
-  - case_if H3.
-    case_if H4.
-    + eapply IHP; eauto.
-    + subst. simpl in *.
-      destruct H1 as [H1 | H1]; try contradiction.
-      subst. simpl in *.
-      omega.
+  - destruct t.
+    + case_if H3.
+      case_if H4.
+      * eapply IHP; eauto.
+      * subst ctrs'. simpl in H1. destruct H1 as [H1 | H1]; try contradiction.
+        subst. simpl. omega.
+    + case_if H3.
+      * eapply IHP; eauto.
+      * subst ctrs'. simpl in H1. destruct H1 as [H1 | H1]; try contradiction.
+        subst. simpl. omega.
+    + case_if H3. 
+      * eapply IHP; eauto.      
 Qed.
 
 

--- a/tests/tests.v
+++ b/tests/tests.v
@@ -3,15 +3,16 @@ Load findel.
 Definition Alice := 101.
 Definition Bob   := 102.
 Definition default_scale := 1.
-Definition now := 1.
+Definition now := 1234.
 Definition time (z : nat) := z.
 Definition fresh_id := 10.
 Definition default_ctr_id := 0.
 Definition default_desc_id := 0.
 Definition default_ledger : list Transaction := [].
 Definition default_gateway : list Gateway := [].
-Definition g1 : Gateway := (gateway 1000 0 100).
-Definition g2 : Gateway := (gateway 1001 1 1000).
+Definition g1 : Gateway := (gateway 1000 0 (now + 100)).
+Definition g2 : Gateway := (gateway 1001 1 (now + 1000)).
+Definition g3_expired : Gateway := (gateway 1002 1 0).
 Definition emptybal : Address -> Currency -> Z :=
   fun (a : Address) (c : Currency) => Z_of_nat 0.
 Definition alice_bal_usd :=
@@ -29,56 +30,222 @@ Eval compute in default_balance Bob EUR.
 Eval compute in default_balance Alice USD.
 Eval compute in default_balance Alice EUR.
 
-Definition default_exec (p : Primitive) :=
-  (execute
+Definition exec (p : Primitive) (t : Time) (gtw : list Gateway) :=
+  (execute 
      p
      default_scale
      Alice
      Bob
      default_balance
-     now
-     default_gateway
+     t
+     gtw
      default_ctr_id
      default_desc_id
      fresh_id
      default_ledger).
 
-Definition default_exec_gtw (p : Primitive) (g : list Gateway) :=
-  (execute
-     p
-     default_scale
-     Alice
-     Bob
-     default_balance
-     now
-     g
-     default_ctr_id
-     default_desc_id
-     fresh_id
-     default_ledger).
+Definition default_exec (p : Primitive) := exec p now default_gateway.
+Definition default_exec_at (p : Primitive) (t : Time) := exec p t default_gateway.
+Definition default_exec_gtw (p : Primitive) (g : list Gateway) := exec p now g.
+
+(*  Helpers for extraction *)
+Definition balance_after_exec (p : Primitive)
+           (party : Address) (c : Currency) :=
+  match default_exec p with
+  | None => None
+  | Some res => match res with
+                  result bal _ _ _ => Some (bal party c)
+                end
+  end.
+Definition balance_after_exec_at
+           (p : Primitive) (t : Time)
+           (party : Address) (c : Currency) :=
+  match default_exec_at p t with
+  | None => None
+  | Some res => match res with
+                  result bal _ _ _ => Some (bal party c)
+                end
+  end.
+Definition balance_after_exec_gtw
+           (p : Primitive) (gtw : list Gateway)
+           (party : Address) (c : Currency) :=
+  match default_exec_gtw p gtw with
+  | None => None
+  | Some res => match res with
+                  result bal _ _ _ => Some (bal party c)
+                end
+  end.
 
 
+
+
+(* Tests *)
+
+(* Test  #0 *)
+Definition T0_zero := Zero.
+(* the contract executes, the balance does not change *)
+Compute default_balance Bob USD.
+Compute balance_after_exec T0_zero Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec T0_zero Alice USD.
+
+
+(* Test  #1 *)
 Definition T1_one := One USD.
+(* the contract executes, Alice pays 1 USD to Bob *)
+Compute default_balance Bob USD.
+Compute balance_after_exec T1_one Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec T1_one Alice USD.
+
+
+(* Test #2 *)
 Definition T2_simple_currency_exchange :=
   (And
      (Give (Scale 11 (One USD)))
      (Scale 10 (One EUR))
   ).
-Definition T3_zcb := (At (now + 1) (Scale 10 (One USD))).
+(* Alice pays 10 EUR to Bob, Bob pays 11 USD to Alice *)
+Compute default_balance Bob USD.
+Compute balance_after_exec T2_simple_currency_exchange Bob USD.
+Compute default_balance Bob EUR.
+Compute balance_after_exec T2_simple_currency_exchange Bob EUR.
+Compute default_balance Alice USD.
+Compute balance_after_exec T2_simple_currency_exchange Alice USD.
+Compute default_balance Alice EUR.
+Compute balance_after_exec T2_simple_currency_exchange Alice EUR.
+
+
+(* Test #3 *)
+Definition T3_zcb := (At (now + 60) (Scale 10 (One USD))).
+(* current time: before now + t, no changes *)
+Compute default_balance Bob USD.
+Compute balance_after_exec_at T3_zcb now Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_at T3_zcb now Alice USD.
+
+(* current time: at now + t, Alice pays 10 USD to Bob *)
+Compute default_balance Bob USD.
+Compute balance_after_exec_at T3_zcb (now + 60) Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_at T3_zcb (now + 60) Alice USD.
+
+(* current time: after (now + t) + Δ + 1, contract deleted *)
+Compute default_balance Bob USD.
+Compute balance_after_exec_at T3_zcb (now + 60 + Δ + 1) Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_at T3_zcb (now + 60 + Δ + 1) Alice USD.
+
+
+(* Test #4 *)
 Definition T4_bond_with_2_coupons :=
   (And
      (And
-        (At (now + 1) (One USD))
-        (At (now + 2) (One EUR))
+        (At (now + 60) (One USD))
+        (At (now + 120) (One EUR))
      )
-     (At (now + 3) (Scale 5 (One USD)))
+     (At (now + 180) (Scale 5 (One USD)))
   ).
+(* current time: before now + 60, three new contracts generated *)
+Compute default_balance Bob USD.
+Compute balance_after_exec_at T4_bond_with_2_coupons now Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_at T4_bond_with_2_coupons now Alice USD.
+Compute default_balance Bob EUR.
+Compute balance_after_exec_at T4_bond_with_2_coupons now Bob EUR.
+Compute default_balance Alice EUR.
+Compute balance_after_exec_at T4_bond_with_2_coupons now Alice EUR.
+Compute
+  match default_exec_at T4_bond_with_2_coupons now with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+(* current time: at now + 60, Alice pays 1 USD to Bob; two new contracts are generated *)
+Compute default_balance Bob USD.
+Compute balance_after_exec_at T4_bond_with_2_coupons (now + 60) Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_at T4_bond_with_2_coupons (now + 60) Alice USD.
+Compute default_exec_at T4_bond_with_2_coupons (now + 60).
+Compute
+  match default_exec_at T4_bond_with_2_coupons (now + 60) with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+(* current time: at (now + 60) + Δ + 1, the sequence fails to execute, no changes *)
+Compute default_exec_at T4_bond_with_2_coupons (now + 60 + Δ + 1).
+
+
+(* Test #5 *)
 Definition T5_european_option :=
-  (At (now + 1) (Or (One USD) (One EUR))).
+  (At (now + 60) (Or (One USD) (One EUR))).
+(* current time: before now + 60, balance does not change, a new contract is generated *)
+Compute default_balance Bob USD.
+Compute balance_after_exec_at T5_european_option now Bob USD.
+Compute default_balance Bob EUR.
+Compute balance_after_exec_at T5_european_option now Bob EUR.
+Compute default_balance Alice USD.
+Compute balance_after_exec_at T5_european_option now Alice USD.
+Compute default_balance Alice EUR.
+Compute balance_after_exec_at T5_european_option now Alice EUR.
+Compute
+  match default_exec_at T5_european_option now with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+(* current time: at now + 60, balance does not change, new option contract is generated *)
+Compute default_balance Bob USD.
+Compute balance_after_exec_at T5_european_option (now + 60) Bob USD.
+Compute default_balance Bob EUR.
+Compute balance_after_exec_at T5_european_option (now + 60) Bob EUR.
+Compute default_balance Alice USD.
+Compute balance_after_exec_at T5_european_option (now + 60) Alice USD.
+Compute default_balance Alice EUR.
+Compute balance_after_exec_at T5_european_option (now + 60) Alice EUR.
+Compute
+  match default_exec_at T5_european_option (now + 60) with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+
+
+(* Test #6 *)
 Definition T6_boolean_gateway (g : Gateway) :=
   (If (gtw_addr g) (One USD) (One EUR)).
+(* gateway g1 status: false, Alice pays 1 EUR to Bob *)
+Compute default_balance Bob EUR.
+Compute balance_after_exec_gtw (T6_boolean_gateway g1) [g1] Bob EUR.
+Compute default_balance Alice EUR.
+Compute balance_after_exec_gtw (T6_boolean_gateway g1) [g1] Alice EUR.
+(* gateway g2 status: true, Alice pays 1 USD to Bob *)
+Compute default_balance Bob USD.
+Compute balance_after_exec_gtw (T6_boolean_gateway g2) [g2] Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_gtw (T6_boolean_gateway g2) [g2] Alice USD.
+(* gateway g3 status: gateway value is not fresh, contract deleted *)
+Compute
+  match default_exec_gtw (T6_boolean_gateway g3_expired) [g3_expired] with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+
+
+(* Test #7 *)
 Definition T7_numeric_gateway :=
   (ScaleObs (gtw_addr g2) (One USD)).
+(* gateway g2 status: true, Alice pays 1 USD to Bob *)
+Compute default_balance Bob USD.
+Compute balance_after_exec_gtw T7_numeric_gateway [g2] Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_gtw (T6_boolean_gateway g2) [g2] Alice USD.
+(* gateway g3 status: gateway value is not fresh, contract deleted *)
+Compute
+  match default_exec_gtw T7_numeric_gateway [g3_expired] with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+
+
+(* Test #8 *)
 Definition T8_complex_scale_obs (g g' : Gateway) :=
   (Scale 10
          (And
@@ -97,6 +264,70 @@ Definition T8_complex_scale_obs (g g' : Gateway) :=
             )
          )
   ).
+(* gateways (g1, g1) status: (false, false)
+ScaleObs fails, If-else is executed: 
+  1) Alice pays 30 USD to Bob
+  2) Bob pays 70 EUR to Alice
+ *)
+Compute default_balance Bob EUR.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g1 g1) [g1;g2] Bob EUR.
+Compute default_balance Alice EUR.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g1 g1) [g1;g2] Alice EUR.
+Compute default_balance Bob USD.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g1 g1) [g1;g2] Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g1 g1) [g1;g2] Alice USD.
+
+(* gateways (g1, g2) status: (false, true) 
+ScaleObs fails, If-true is executed: balance does not change
+ *)
+Compute default_balance Bob EUR.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g1 g2) [g1;g2] Bob EUR.
+Compute default_balance Alice EUR.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g1 g2) [g1;g2] Alice EUR.
+Compute default_balance Bob USD.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g1 g2) [g1;g2] Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g1 g2) [g1;g2] Alice USD.
+(* gateways (g2, g1) status: (true, false) 
+ScaleObs succeeds, If-false is executed: 
+  1) Alice pays 30 USD to Bob
+  2) Bob pays 70 EUR to Alice
+  3) an option contract for Alice is generated
+ *)
+Compute default_balance Bob EUR.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g2 g1) [g1;g2] Bob EUR.
+Compute default_balance Alice EUR.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g2 g1) [g1;g2] Alice EUR.
+Compute default_balance Bob USD.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g2 g1) [g1;g2] Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g2 g1) [g1;g2] Alice USD.
+Compute
+  match default_exec_gtw (T8_complex_scale_obs g2 g1) [g1;g2] with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+(* gateways (g2, g2) status: (true, true) 
+ScaleObs succeeds, If-true is executed: 
+  1) an option contract for Alice is generated
+ *)
+Compute default_balance Bob EUR.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g2 g2) [g1;g2] Bob EUR.
+Compute default_balance Alice EUR.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g2 g2) [g1;g2] Alice EUR.
+Compute default_balance Bob USD.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g2 g2) [g1;g2] Bob USD.
+Compute default_balance Alice USD.
+Compute balance_after_exec_gtw (T8_complex_scale_obs g2 g2) [g1;g2] Alice USD.
+Compute
+  match default_exec_gtw (T8_complex_scale_obs g2 g2) [g1;g2] with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+
+
+(* Test #9 *)
 Definition T9_timebound (g : Gateway) (t0 t1 : nat) :=
   (Timebound (interval t0 t1)
              (ScaleObs (gtw_addr g)
@@ -108,311 +339,37 @@ Definition T9_timebound (g : Gateway) (t0 t1 : nat) :=
 
              )
   ).
-
-
-Eval compute in default_exec T1_one.
-Eval compute in
-    (match default_exec T1_one with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob USD
-                   end
-     end
-    ).
-Eval compute in
-    (match default_exec T1_one with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice USD
-                   end
-     end
-    ).
-
-
-
-Eval compute in default_exec T2_simple_currency_exchange.
-Eval compute in
-    (match default_exec T2_simple_currency_exchange with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob USD
-                   end
-     end
-    ).
-Eval compute in
-    (match default_exec T2_simple_currency_exchange with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice USD
-                   end
-     end
-    ).
-Eval compute in
-    (match default_exec T2_simple_currency_exchange with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match default_exec T2_simple_currency_exchange with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice EUR
-                   end
-     end
-    ).
-
-
-Eval compute in default_exec T3_zcb.
-Eval compute in
-    (match default_exec T3_zcb with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob USD
-                   end
-     end
-    ).
-Eval compute in
-    (match default_exec T3_zcb with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice USD
-                   end
-     end
-    ).
-
-
-Eval compute in default_exec T5_european_option.
-Eval compute in
-    (match default_exec T5_european_option with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob USD
-                   end
-     end
-    ).
-Eval compute in
-    (match default_exec T5_european_option with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice USD
-                   end
-     end
-    ).
-Eval compute in
-    (match default_exec T5_european_option with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match default_exec T5_european_option with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match default_exec T5_european_option with
-     | None => []
-     | Some res => match res with
-                     result _ c _ _ => c
-                   end
-     end
-    ).
-
-
-Eval compute in (default_exec_gtw (T6_boolean_gateway g1) [g1]).
-Eval compute in
-    (match (default_exec_gtw (T6_boolean_gateway g1) [g1]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw (T6_boolean_gateway g1) [g1]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice EUR
-                   end
-     end
-    ).
-Eval compute in (default_exec_gtw (T6_boolean_gateway g2) [g2]).
-Eval compute in
-    (match (default_exec_gtw (T6_boolean_gateway g2) [g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob USD
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw (T6_boolean_gateway g2) [g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice USD
-                   end
-     end
-    ).
-
-Eval compute in (default_exec_gtw T7_numeric_gateway [g2]).
-Eval compute in
-    (match (default_exec_gtw T7_numeric_gateway [g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob USD
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw T7_numeric_gateway [g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice USD
-                   end
-     end
-    ).
-
-
-Eval compute in (default_exec_gtw (T8_complex_scale_obs g1 g2) [g1; g2]).
-Eval compute in
-    (match (default_exec_gtw  (T8_complex_scale_obs g1 g2) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob USD
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw  (T8_complex_scale_obs g1 g2) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice USD
-                   end
-     end
-    ).
-Eval compute in (default_exec_gtw (T8_complex_scale_obs g2 g1) [g1; g2]).
-Eval compute in
-    (match (default_exec_gtw  (T8_complex_scale_obs g2 g1) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob USD
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw  (T8_complex_scale_obs g2 g1) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice USD
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw  (T8_complex_scale_obs g1 g2) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw  (T8_complex_scale_obs g1 g2) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice EUR
-                   end
-     end
-    ).
-Eval compute in (default_exec_gtw (T8_complex_scale_obs g2 g1) [g1; g2]).
-Eval compute in
-    (match (default_exec_gtw  (T8_complex_scale_obs g2 g1) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw  (T8_complex_scale_obs g2 g1) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice EUR
-                   end
-     end
-    ).
-
-
-
-Eval compute in (default_exec_gtw (T9_timebound g1 0 10) [g1; g2]).
-Eval compute in
-    (match (default_exec_gtw (T9_timebound g1 0 10) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw (T9_timebound g1 0 10) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw (T9_timebound g1 0 10) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw (T9_timebound g1 0 10) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw (T9_timebound g2 0 10) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw (T9_timebound g1 0 10) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw (T9_timebound g1 0 10) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Bob EUR
-                   end
-     end
-    ).
-Eval compute in
-    (match (default_exec_gtw (T9_timebound g1 0 10) [g1; g2]) with
-     | None => 0%Z
-     | Some res => match res with
-                     result bal _ _ _ => bal Alice EUR
-                   end
-     end
-    ).
+(* current time: before now, the contract is available for execution in the future *)
+Compute
+  match exec (T9_timebound g1 now (now + 60)) (pred now) [g1;g2] with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+(* current time: now
+   gateway g1 status: scale 1
+   the option contract is generated, with Bob as issuer, Alice as p_owner, and scale 0
+*)
+Compute
+  match exec (T9_timebound g1 now (now + 60)) now [g1;g2] with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+(* current time: now
+   gateway g2 status: scale 1
+   the timebound contract is executed
+   an option contract is generated, with Bob as issuer, Alice as proposed owner, and scale 1
+*)
+Compute
+  match exec (T9_timebound g2 now (now + 60)) now [g1;g2] with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.
+(* current time: now
+   gateway g3_expired status: expired
+   no contract is generated
+ *)
+Compute
+  match exec (T9_timebound g3_expired now (now + 60)) now [g1;g2;g3_expired] with
+  | None => None
+  | Some (result _ A _ _) => Some A
+  end.

--- a/tests/tests.v
+++ b/tests/tests.v
@@ -98,7 +98,7 @@ Definition T8_complex_scale_obs (g g' : Gateway) :=
          )
   ).
 Definition T9_timebound (g : Gateway) (t0 t1 : nat) :=
-  (Timebound t0 t1
+  (Timebound (interval t0 t1)
              (ScaleObs (gtw_addr g)
                        (Give (Or
                                 (Scale 5 (One USD))


### PR DESCRIPTION
This PR removes the useless and inconsistent axiom `infinite` from `src`.
Timebound uses time intervals now. Due to this change, a single test and two proofs needed some updates.
